### PR TITLE
Update nav.adoc

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -112,7 +112,7 @@
 ** xref:lab-environment-introduction.adoc#container-registry[Container Registry]
 ** xref:lab-environment-introduction.adoc#openshift-hub-cluster[OpenShift Hub Cluster]
 
-* xref:crafting-deployments-iaac.adoc[Crafting Deployment's IaaC] 
+* xref:crafting-deployments-iaac.adoc[Crafting Deployment's IaC] 
 ** xref:crafting-deployments-iaac.adoc#introduction-to-siteconfig[Introduction to the SiteConfig]
 ** xref:crafting-deployments-iaac.adoc#crafting-our-own-siteconfig[Crafting our own SiteConfig]
 *** xref:crafting-deployments-iaac.adoc#git-repository[Git Repository]


### PR DESCRIPTION
Infrastructure as Code is IaC not IaaC. So I propose to replace IaaC by IaC for consistency.

This is confirmed by the content of the page: 
Crafting the Deployment Infrastructure as Code
In RAN environments we will be managing thousands of Single Node OpenShift (SNO) instances, and as such, a scalable and manageable way of defining our infrastructure is required.

By describing our infrastructure as code (IaC) the git repository holds declarative state of the fleet.